### PR TITLE
Fix birthdates, refs: #49442

### DIFF
--- a/db/migrate/20190607093331_fix_birthdate.rb
+++ b/db/migrate/20190607093331_fix_birthdate.rb
@@ -1,0 +1,12 @@
+class FixBirthdate < ActiveRecord::Migration[5.2]
+  # Because this is a data correction, we only write an up method in this migration
+  def up
+    Person.includes(:company).find_each do |person|
+      if (person.birthdate.time.hour != 0) 
+        correct_birthdate = person.birthdate.time.change(hour: 0)
+        correct_birthdate += 1.days
+        person.update_column(:birthdate, correct_birthdate)
+      end
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_14_113640) do
+ActiveRecord::Schema.define(version: 2019_06_07_093331) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/frontend/app/templates/components/person-edit.hbs
+++ b/frontend/app/templates/components/person-edit.hbs
@@ -132,7 +132,8 @@
                     <div id="date_location" class="birthdate_pikaday">
                       {{pikaday-input
                         onSelection=(action "setBirthdate")
-                        value=person.birthdate}}
+                        value=person.birthdate
+                        useUTC=true}}
                     </div>
                   </td>
                 </tr>

--- a/frontend/app/templates/components/person-new.hbs
+++ b/frontend/app/templates/components/person-new.hbs
@@ -126,7 +126,8 @@
                     <div id="date_location" class="birthdate_pikaday">
                       {{pikaday-input
                         onSelection=(action "setBirthdate")
-                        value=newPerson.birthdate}}
+                        value=newPerson.birthdate
+                        useUTC=true}}
                     </div>
                   </div>
                 </td>

--- a/spec/migrations/fix_birthdate_spec.rb
+++ b/spec/migrations/fix_birthdate_spec.rb
@@ -1,0 +1,50 @@
+require 'rails_helper'
+migration_file_name = Dir[Rails.root.join('db/migrate/20190607093331_fix_birthdate.rb')].first
+require migration_file_name
+
+describe FixBirthdate do
+
+  let(:migration) { FixBirthdate.new }
+  let(:bob) { people(:bob) }
+
+  def silent
+    verbose = ActiveRecord::Migration.verbose = false
+    yield
+
+    ActiveRecord::Migration.verbose = verbose
+  end
+
+  around do |test|
+    silent { test.run }
+  end
+
+  context 'up' do
+    it 'increments day and sets hour to 0' do
+      bob.birthdate = bob.birthdate.time.change(hour: 22)
+      bob.birthdate = bob.birthdate.change(day: 20)
+      bob.save!
+
+      migration.up
+
+      bob.reload
+
+      expect(bob.birthdate.time.hour).to eq(0)
+      expect(bob.birthdate.day).to eq(21)
+    end
+
+    it 'increments day correctly to next month' do
+      bob.birthdate = bob.birthdate.time.change(hour: 22)
+      bob.birthdate = bob.birthdate.change(day: 30)
+      bob.birthdate = bob.birthdate.change(month: 6)
+      bob.save!
+
+      migration.up
+
+      bob.reload
+
+      expect(bob.birthdate.time.hour).to eq(0)
+      expect(bob.birthdate.day).to eq(1)
+      expect(bob.birthdate.month).to eq(7)
+    end
+  end
+end


### PR DESCRIPTION
Fixes #200 
So what happened was that it was saved in our local timezone which lead to us saving for example 2019-06-06 22:00:00 instead of 2019-06-07 00:00:00

Was tested with a prod dump