### PR TITLE
Update category seeder

### DIFF
--- a/db/seeds/support/category_seeder.rb
+++ b/db/seeds/support/category_seeder.rb
@@ -1,13 +1,13 @@
 class CategorySeeder
   def seed_categories(categories)
     categories.each_with_index do |(parent, children), parent_index|
-      parent_category = Category.seed(:title) do |pc|
+      parent_category = Category.seed(:position) do |pc|
         pc.title = parent
         pc.position = (1 + parent_index) * 100
       end.first || Category.find_by(title: parent)
 
       children.each_with_index do |child, child_index|
-        Category.seed(:title) do |cc|
+        Category.seed(:position) do |cc|
           cc.title = child
           cc.parent_id = parent_category.id
           cc.position = parent_category.position + child_index  + 1

--- a/spec/seeders/category_seeder_spec.rb
+++ b/spec/seeders/category_seeder_spec.rb
@@ -20,7 +20,7 @@ describe CategorySeeder do
         expect do
           SeedFu.quiet = true
           seeder.seed_categories(categories)
-        end.to change { Category.count }.by(6)
+        end.to change { Category.count }.by(1)
         categories.flatten(2).each do |category|
           expect(Category.all.map(&:title)).to include(category.to_s)
         end


### PR DESCRIPTION
Currently we seeded by title. This doesn't work though because as soon as you rename a category in settings.yml it creates a new record and doesn't override the old category. I used this commit as a hotfix for 4.2.0... Question is, if we want to seed by position because if you'd simply want to completely replace a category with another and don't want to take over the old skills that were attached to the old category this wouldn't work.