### PR TITLE
Issue #337 sorting_of_skills_when_adding_a_new_one

### DIFF
--- a/frontend/app/components/people-skill-new.js
+++ b/frontend/app/components/people-skill-new.js
@@ -39,16 +39,16 @@ export default Component.extend({
   }),
 
   orderByTitleCaseInsensitive(firstSkill, secondSkill) {
-    let firstTitle =
-      firstSkill.get("title") == undefined
-        ? undefined
-        : firstSkill.get("title").toLowerCase();
-    let secondTitle =
-      secondSkill.get("title") == undefined
-        ? undefined
-        : secondSkill.get("title").toLowerCase();
+    let firstTitle = firstSkill.title && firstSkill.title.toLowerCase();
+    let secondTitle = secondSkill.title && secondSkill.title.toLowerCase();
 
-    return firstTitle < secondTitle ? -1 : 1;
+    if (firstTitle < secondTitle) {
+      return -1;
+    }
+    if (secondTitle > firstTitle) {
+      return 1;
+    }
+    return 0;
   },
 
   newSkillSelected: computed("newPeopleSkill.skill", function() {

--- a/frontend/app/components/people-skill-new.js
+++ b/frontend/app/components/people-skill-new.js
@@ -34,9 +34,22 @@ export default Component.extend({
       skills = skills.filter(
         skill => !peopleSkillsIds.includes(skill.get("id"))
       );
-      return skills.sort((a, b) => (a.get("title") < b.get("title") ? -1 : 1));
+      return skills.sort((a, b) => this.orderByTitleCaseInsensitive(a, b));
     });
   }),
+
+  orderByTitleCaseInsensitive(firstSkill, secondSkill) {
+    let firstTitle =
+      firstSkill.get("title") == undefined
+        ? undefined
+        : firstSkill.get("title").toLowerCase();
+    let secondTitle =
+      secondSkill.get("title") == undefined
+        ? undefined
+        : secondSkill.get("title").toLowerCase();
+
+    return firstTitle < secondTitle ? -1 : 1;
+  },
 
   newSkillSelected: computed("newPeopleSkill.skill", function() {
     if (this.get("newPeopleSkill.skill.content") == null) return false;

--- a/frontend/tests/acceptance/create-people-skill-test.js
+++ b/frontend/tests/acceptance/create-people-skill-test.js
@@ -59,7 +59,7 @@ module("Acceptance | create people-skill", function(hooks) {
       .map(title => title.text);
 
     assert.equal(titles[0], "Bash");
-    assert.equal(titles[1], "c");
+    assert.equal(titles[1], "cunit");
     assert.equal(titles[2], "JUnit");
   });
 });

--- a/frontend/tests/acceptance/create-people-skill-test.js
+++ b/frontend/tests/acceptance/create-people-skill-test.js
@@ -39,7 +39,7 @@ module("Acceptance | create people-skill", function(hooks) {
   });
 
   test("checks if the skill titles are listed alphabetically and case-insensitive", async function(assert) {
-    assert.expect(3);
+    assert.expect(4);
 
     // Go to the start page and select a user from the dropdown
     await applicationPage.visitHome("/");
@@ -58,8 +58,9 @@ module("Acceptance | create people-skill", function(hooks) {
       .toArray()
       .map(title => title.text);
 
-    assert.equal(titles[0], "Bash");
-    assert.equal(titles[1], "cunit");
-    assert.equal(titles[2], "JUnit");
+    assert.equal(titles[0], "");
+    assert.equal(titles[1], "Bash");
+    assert.equal(titles[2], "cunit");
+    assert.equal(titles[3], "JUnit");
   });
 });

--- a/frontend/tests/acceptance/create-people-skill-test.js
+++ b/frontend/tests/acceptance/create-people-skill-test.js
@@ -37,4 +37,29 @@ module("Acceptance | create people-skill", function(hooks) {
     let levels = page.peopleSkillsTable.levels.toArray().map(name => name.text);
     assert.ok(levels.includes("Trainee 1"));
   });
+
+  test("checks if the skill titles are listed alphabetically and case-insensitive", async function(assert) {
+    assert.expect(3);
+
+    // Go to the start page and select a user from the dropdown
+    await applicationPage.visitHome("/");
+    await selectChoose("#people-search", ".ember-power-select-option", 1);
+
+    // Visits person/:id/skills
+    await page.visit({ person_id: /\d+$/.exec(currentURL()) });
+
+    // Open the modal and subsequently open the skill dropdown
+    /* eslint "no-undef": "off" */
+    await page.newPeopleSkillModal.openModalButton();
+    await page.newPeopleSkillModal.openSkillTitleDropdown();
+
+    // Map all the available skills in the dropdown to an array
+    let titles = page.newPeopleSkillModal.skillTitleDropdownOptions
+      .toArray()
+      .map(title => title.text);
+
+    assert.equal(titles[0], "Bash");
+    assert.equal(titles[1], "c");
+    assert.equal(titles[2], "JUnit");
+  });
 });

--- a/frontend/tests/acceptance/edit-skill-test.js
+++ b/frontend/tests/acceptance/edit-skill-test.js
@@ -14,8 +14,8 @@ module("Acceptance | edit skill", function(hooks) {
 
     assert.equal(currentURL(), "/skills");
 
-    assert.equal(page.indexPage.skills.skillNames.toArray()[2].text, "Rails");
-    await page.indexPage.skills.skillEditButtons.toArray()[2].clickOn();
+    assert.equal(page.indexPage.skills.skillNames.toArray()[3].text, "Rails");
+    await page.indexPage.skills.skillEditButtons.toArray()[3].clickOn();
 
     await page.indexPage.skillEdit.skillName("Travis CI");
     await page.indexPage.skillEdit.skillDefaultSet();
@@ -26,7 +26,7 @@ module("Acceptance | edit skill", function(hooks) {
     await selectChoose(".skill-edit-portfolio", "aktiv");
     await page.indexPage.skillEdit.save();
 
-    let rows = page.indexPage.skills.skillRow.toArray()[3].text;
+    let rows = page.indexPage.skills.skillRow.toArray()[4].text;
     assert.ok(rows.includes("Travis CI"));
     assert.ok(rows.includes("System-Engineering"));
     assert.ok(rows.includes("Linux-Engineering"));

--- a/frontend/tests/acceptance/filter-skills-test.js
+++ b/frontend/tests/acceptance/filter-skills-test.js
@@ -8,7 +8,7 @@ module("Acceptance | filter skills", function(hooks) {
   setupApplicationTest(hooks);
 
   test("filters nothing and shows every skill", async function(assert) {
-    assert.expect(4);
+    assert.expect(5);
 
     await page.indexPage.visit();
 
@@ -20,10 +20,11 @@ module("Acceptance | filter skills", function(hooks) {
     assert.ok(names.includes("JUnit"));
     assert.ok(names.includes("• Bash"));
     assert.ok(names.includes("Rails") || names.includes("Travis CI"));
+    assert.ok(names.includes("cunit"));
   });
 
   test("filters only defaultSet by default", async function(assert) {
-    assert.expect(5);
+    assert.expect(6);
 
     await page.indexPage.visit();
 
@@ -37,6 +38,7 @@ module("Acceptance | filter skills", function(hooks) {
       .map(name => name.text);
     assert.notOk(names.includes("JUnit"));
     assert.notOk(names.includes("Bash"));
+    assert.notOk(names.includes("cunit"));
     assert.ok(names.includes("Rails"));
   });
 

--- a/frontend/tests/acceptance/show-skill-test.js
+++ b/frontend/tests/acceptance/show-skill-test.js
@@ -13,7 +13,7 @@ module("Acceptance | show skill", function(hooks) {
 
     assert.equal(currentURL(), "/skills");
 
-    await page.indexPage.skills.skillNames.toArray()[2].clickOn();
+    await page.indexPage.skills.skillNames.toArray()[3].clickOn();
 
     let names = page.indexPage.skillModal.personNames
       .toArray()
@@ -30,7 +30,7 @@ module("Acceptance | show skill", function(hooks) {
 
     assert.equal(currentURL(), "/skills");
 
-    await page.indexPage.skills.skillNames.toArray()[1].clickOn();
+    await page.indexPage.skills.skillNames.toArray()[2].clickOn();
 
     let names = page.indexPage.skillModal.personNames
       .toArray()

--- a/frontend/tests/pages/person-skills.js
+++ b/frontend/tests/pages/person-skills.js
@@ -23,6 +23,8 @@ export default create({
     openModalButton: clickable(
       'a.edit-buttons[data-target="#people-skill-new-modal"]'
     ),
+    openSkillTitleDropdown: clickable("#people-skill-new-skill"),
+    skillTitleDropdownOptions: collection(".ember-power-select-option"),
     levelButtons: collection(".people-skill-new-dropdowns .slider-tick"),
     interestButtons: collection(
       ".people-skill-new-dropdowns .icon-rating-icon"

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -11,7 +11,7 @@ describe CategoriesController do
 
         categories = json['data']
 
-        expect(categories.count).to eq(5)
+        expect(categories.count).to eq(6)
         java_attrs = categories.third['attributes']
         expect(java_attrs.count).to eq (3)
         expect(java_attrs['title']).to eq ('Java')
@@ -30,7 +30,7 @@ describe CategoriesController do
         expect(category_titles).to include('Software-Engineering')
         expect(category_titles).to include('System-Engineering')
         software_engineering_attrs = categories.second['attributes']
-        expect(software_engineering_attrs.count).to eq (3)
+        expect(software_engineering_attrs.count).to eq (4)
         expect(software_engineering_attrs['parent_id']).to eq (nil)
         json_object_includes_keys(software_engineering_attrs, keys)
       end

--- a/spec/controllers/categories_controller_spec.rb
+++ b/spec/controllers/categories_controller_spec.rb
@@ -30,7 +30,7 @@ describe CategoriesController do
         expect(category_titles).to include('Software-Engineering')
         expect(category_titles).to include('System-Engineering')
         software_engineering_attrs = categories.second['attributes']
-        expect(software_engineering_attrs.count).to eq (4)
+        expect(software_engineering_attrs.count).to eq (3)
         expect(software_engineering_attrs['parent_id']).to eq (nil)
         json_object_includes_keys(software_engineering_attrs, keys)
       end

--- a/spec/controllers/skills_controller_spec.rb
+++ b/spec/controllers/skills_controller_spec.rb
@@ -48,11 +48,9 @@ describe SkillsController do
         get :index, params: { defaultSet: 'new' }
 
         skills = json['data']
-        expect(skills.count).to eq(2)
+        expect(skills.count).to eq(1)
         bash_attrs = skills.first['attributes']
-        cunit_attrs = skills.second['attributes']
         expect(bash_attrs['title']).to eq ('Bash')
-        expect(cunit_attrs['title']).to eq ('cunit')
       end
 
       it 'returns skills with parent category software-engineering' do

--- a/spec/controllers/skills_controller_spec.rb
+++ b/spec/controllers/skills_controller_spec.rb
@@ -17,7 +17,7 @@ describe SkillsController do
 
         skills = json['data']
 
-        expect(skills.count).to eq(3)
+        expect(skills.count).to eq(4)
         bash_attrs = skills.first['attributes']
         expect(bash_attrs.count).to eq (5)
         expect(bash_attrs['title']).to eq ('Bash')
@@ -48,9 +48,11 @@ describe SkillsController do
         get :index, params: { defaultSet: 'new' }
 
         skills = json['data']
-        expect(skills.count).to eq(1)
+        expect(skills.count).to eq(2)
         bash_attrs = skills.first['attributes']
+        cunit_attrs = skills.second['attributes']
         expect(bash_attrs['title']).to eq ('Bash')
+        expect(cunit_attrs['title']).to eq ('cunit')
       end
 
       it 'returns skills with parent category software-engineering' do
@@ -58,9 +60,13 @@ describe SkillsController do
         get :index, params: { category: parent_category.id }
 
         skills = json['data']
-        expect(skills.count).to eq(2)
-        junit_attrs = skills.first['attributes']
+        expect(skills.count).to eq(3)
+        cunit_attrs = skills.first['attributes']
+        junit_attrs = skills.second['attributes']
+        rails_attrs = skills.third['attributes']
+        expect(cunit_attrs['title']).to eq ('cunit')
         expect(junit_attrs['title']).to eq ('JUnit')
+        expect(rails_attrs['title']).to eq ('Rails')
       end
 
       it 'returns skills with parent category software-engineering and defaultSet true' do
@@ -97,7 +103,7 @@ describe SkillsController do
 
         skills = json['data']
 
-        expect(skills.count).to eq(3)
+        expect(skills.count).to eq(4)
       end
     end
   end

--- a/spec/domain/skills_filter_spec.rb
+++ b/spec/domain/skills_filter_spec.rb
@@ -10,8 +10,8 @@ describe SkillsFilter do
       expect(filteredSkills.count).to eq(4)
       expect(filteredSkills[0].title).to eq('Rails')
       expect(filteredSkills[1].title).to eq('JUnit')
-      expect(filteredSkills[2].title).to eq('cunit')
-      expect(filteredSkills[3].title).to eq('Bash')
+      expect(filteredSkills[2].title).to eq('Bash')
+      expect(filteredSkills[3].title).to eq('cunit')
     end
 
     it 'filters skills by category' do
@@ -36,17 +36,17 @@ describe SkillsFilter do
       filter = SkillsFilter.new(Skill.all, nil, nil, 'new')
       filteredSkills = filter.scope
 
-      expect(filteredSkills.count).to eq(2)
-      expect(filteredSkills[0].title).to eq('cunit')
-      expect(filteredSkills[1].title).to eq('Bash')
+      expect(filteredSkills.count).to eq(1)
+      expect(filteredSkills[0].title).to eq('Bash')
     end
     
     it 'filters skills by category, default set and title' do
       filter = SkillsFilter.new(Skill.all, 458108788, 'u', 'false')
       filteredSkills = filter.scope
 
-      expect(filteredSkills.count).to eq(1)
+      expect(filteredSkills.count).to eq(2)
       expect(filteredSkills[0].title).to eq('JUnit')
+      expect(filteredSkills[1].title).to eq('cunit')
     end
   end
 end

--- a/spec/domain/skills_filter_spec.rb
+++ b/spec/domain/skills_filter_spec.rb
@@ -7,19 +7,21 @@ describe SkillsFilter do
       filter = SkillsFilter.new(Skill.all, nil, nil, nil)
       filteredSkills = filter.scope
 
-      expect(filteredSkills.count).to eq(3)
+      expect(filteredSkills.count).to eq(4)
       expect(filteredSkills[0].title).to eq('Rails')
       expect(filteredSkills[1].title).to eq('JUnit')
-      expect(filteredSkills[2].title).to eq('Bash')
+      expect(filteredSkills[2].title).to eq('cunit')
+      expect(filteredSkills[3].title).to eq('Bash')
     end
 
     it 'filters skills by category' do
       filter = SkillsFilter.new(Skill.all, 458108788, nil, nil)
       filteredSkills = filter.scope
 
-      expect(filteredSkills.count).to eq(2)
+      expect(filteredSkills.count).to eq(3)
       expect(filteredSkills[0].title).to eq('Rails')
       expect(filteredSkills[1].title).to eq('JUnit')
+      expect(filteredSkills[2].title).to eq('cunit')
     end
     
     it 'filters skills by title' do
@@ -34,8 +36,9 @@ describe SkillsFilter do
       filter = SkillsFilter.new(Skill.all, nil, nil, 'new')
       filteredSkills = filter.scope
 
-      expect(filteredSkills.count).to eq(1)
-      expect(filteredSkills[0].title).to eq('Bash')
+      expect(filteredSkills.count).to eq(2)
+      expect(filteredSkills[0].title).to eq('cunit')
+      expect(filteredSkills[1].title).to eq('Bash')
     end
     
     it 'filters skills by category, default set and title' do

--- a/spec/exporters/csv/skillset_spec.rb
+++ b/spec/exporters/csv/skillset_spec.rb
@@ -5,7 +5,7 @@ describe Csv::Skillset do
     it 'exports' do
       csv = Csv::Skillset.new(Skill.all).export
       csv = csv.split("\n")
-      expect(csv.length).to eq(4)
+      expect(csv.length).to eq(5)
       expect(csv.first.split(",").length).to eq(7)
       rails = csv.select { |s| s.include?('Rails') && s.include?('2') }.first
       expect(rails).not_to eq (nil)

--- a/spec/fixtures/categories.yml
+++ b/spec/fixtures/categories.yml
@@ -21,3 +21,8 @@ java:
   position: 102
   title: Java
   parent: software-engineering
+
+c:
+  position: 103
+  title: c
+  parent: software-engineering

--- a/spec/fixtures/skills.yml
+++ b/spec/fixtures/skills.yml
@@ -32,8 +32,9 @@ bash:
   portfolio: 2
   category: linux-engineering
 
-c:
-  title: c
+cunit:
+  title: cunit
   radar: 1
   portfolio: 2
+  default_set: false
   category: c

--- a/spec/fixtures/skills.yml
+++ b/spec/fixtures/skills.yml
@@ -31,3 +31,9 @@ bash:
   radar: 1
   portfolio: 2
   category: linux-engineering
+
+c:
+  title: c
+  radar: 1
+  portfolio: 2
+  category: c

--- a/spec/models/category_spec.rb
+++ b/spec/models/category_spec.rb
@@ -51,12 +51,13 @@ describe Category do
       categories = Category.all_children
       expect(categories.first).to eq(categories(:ruby))
       expect(categories.second).to eq(categories(:java))
-      expect(categories.third).to eq(categories(:'linux-engineering'))
+      expect(categories.third).to eq(categories(:'c'))
+      expect(categories.fourth).to eq(categories(:'linux-engineering'))
     end
 
     it 'orders all skills correctly' do
       categories = Category.list.pluck(:title)
-      expect(categories).to eq(['Software-Engineering', 'Ruby', 'Java', 'System-Engineering', 'Linux-Engineering'])
+      expect(categories).to eq(["Software-Engineering", "Ruby", "Java", "c", "System-Engineering", "Linux-Engineering"])
     end
   end
 end


### PR DESCRIPTION
changed the dropdown in the new-Skill-modal to list the available skills alphabetically and case-insensitively, and added a test to check the feature