### PR TITLE
fixed table header in sticky position

### DIFF
--- a/frontend/app/styles/custom.scss
+++ b/frontend/app/styles/custom.scss
@@ -327,7 +327,6 @@ div.row-fluid.person-list > div.span10 > div.container-fluid.round-border {
 }
 
 #skills-list-table thead {
-  top: 203px;
   z-index: 999 !important;
 }
 
@@ -339,6 +338,8 @@ div.row-fluid.person-list > div.span10 > div.container-fluid.round-border {
 
 #skills-list-table th {
   font-weight: normal;
+  position: sticky;
+  top: 203px;
 }
 
 #skills-list-table .skillname span {

--- a/frontend/app/templates/components/skills-list.hbs
+++ b/frontend/app/templates/components/skills-list.hbs
@@ -26,7 +26,7 @@
 <div class="mb-end">
   <SkillNew @refreshList={{action "refreshList"}} />
   <table id="skills-list-table" class="table">
-    <thead class="position-sticky">
+    <thead>
       <tr>
         <th scope="col" class="bg-info header-text text-secondary">Skill</th>
         <th scope="col" class="w-9 text-secondary">Members</th>


### PR DESCRIPTION
The class position-sticky, defined on <thead> did not seem to  work as intended for Chrome.

To resolve the issue, the standard way of implementing sticky table headers was used.

https://adrianroselli.com/2020/01/fixed-table-headers.html