### PR TITLE
Allow non admin people to access skillset

### DIFF
--- a/frontend/app/components/skills-list-row-edit.js
+++ b/frontend/app/components/skills-list-row-edit.js
@@ -35,6 +35,8 @@ export default Component.extend({
 
   // checks if the focus of the event e comes from outside the current powerselect or the inside
   focusComesFromOutside(e) {
+    if (!this.get("isAdmin")) return;
+
     let blurredEl = e.relatedTarget;
     if (isBlank(blurredEl)) {
       return false;

--- a/frontend/app/components/skills-list-row-edit.js
+++ b/frontend/app/components/skills-list-row-edit.js
@@ -35,8 +35,6 @@ export default Component.extend({
 
   // checks if the focus of the event e comes from outside the current powerselect or the inside
   focusComesFromOutside(e) {
-    if (!this.get("isAdmin")) return;
-
     let blurredEl = e.relatedTarget;
     if (isBlank(blurredEl)) {
       return false;

--- a/frontend/app/components/skills-list-row-show.js
+++ b/frontend/app/components/skills-list-row-show.js
@@ -1,10 +1,18 @@
 import classic from "ember-classic-decorator";
 import { tagName } from "@ember-decorators/component";
 import Component from "@ember/component";
+import { inject as service } from "@ember/service";
 
 @classic
 @tagName("tr")
 export default class SkillsListRowShow extends Component {
+  @service("keycloak-session")
+  session;
+  init() {
+    super.init(...arguments);
+    let session = this.get("session");
+    this.set("isAdmin", session.hasResourceRole("ADMIN"));
+  }
   click() {
     this.sendAction("toggleSkill", this.get("skill"));
   }

--- a/frontend/app/components/skills-list.js
+++ b/frontend/app/components/skills-list.js
@@ -6,6 +6,9 @@ import Component from "@ember/component";
 
 @classic
 export default class SkillsList extends Component {
+  @service("keycloak-session")
+  session;
+  @service intl;
   @service store;
 
   @service download;
@@ -25,6 +28,8 @@ export default class SkillsList extends Component {
       "categories",
       this.get("store").findAll("category", { reload: true })
     );
+    let session = this.get("session");
+    this.set("isAdmin", session.hasResourceRole("ADMIN"));
   }
 
   @computed("categories")
@@ -49,8 +54,25 @@ export default class SkillsList extends Component {
   }
 
   @action
+  displayCreateSkillError() {
+    let title = this.get("intl").t(`error-message.unauthorized`);
+    let message = this.get("intl").t(`error-message.cannotCreateSkill`);
+    this.get("notify").alert(title + ":" + "\n" + message, {
+      closeAfter: 10000
+    });
+  }
+
+  @action
   startEditing(skill) {
-    this.editSkills.addObject(skill);
+    if (!this.get("isAdmin")) {
+      let title = this.get("intl").t(`error-message.unauthorized`);
+      let message = this.get("intl").t(`error-message.cannotEditSkill`);
+      this.get("notify").alert(title + ":" + "\n" + message, {
+        closeAfter: 10000
+      });
+    } else {
+      this.editSkills.addObject(skill);
+    }
   }
 
   @action

--- a/frontend/app/initializers/keycloak.js
+++ b/frontend/app/initializers/keycloak.js
@@ -8,6 +8,7 @@ export function initialize(application) {
     application.inject("route", "session", "service:keycloakStub");
     application.inject("controller", "session", "service:keycloakStub");
     application.inject("adapter", "session", "service:keycloakStub");
+    application.inject("component", "session", "service:keycloakStub");
   }
 }
 

--- a/frontend/app/routes/skills.js
+++ b/frontend/app/routes/skills.js
@@ -12,9 +12,4 @@ export default class SkillsRoute extends Route.extend(
 
   @service
   router;
-
-  beforeModel() {
-    if (!this.get("session").hasResourceRole("ADMIN"))
-      this.get("router").transitionTo("people");
-  }
 }

--- a/frontend/app/styles/app.scss
+++ b/frontend/app/styles/app.scss
@@ -382,3 +382,7 @@ $theme-colors: (
 input.invalid {
   box-shadow: 0 0 3px #cc0000;
 }
+
+.grayed-out {
+  -webkit-filter: grayscale(100%);
+}

--- a/frontend/app/templates/application.hbs
+++ b/frontend/app/templates/application.hbs
@@ -50,13 +50,11 @@
                   {{t "application.cvSearch"}}
                 </LinkTo>
               </li>
-              {{#if this.isAdmin}}
-                <li class="nav-item hovering-nav-bar">
-                  <LinkTo @route="skills" class="nav-link text-white rounded-0">
-                    Skillset
-                  </LinkTo>
-                </li>
-              {{/if}}
+              <li class="nav-item hovering-nav-bar">
+                <LinkTo @route="skills" class="nav-link text-white rounded-0">
+                  Skillset
+                </LinkTo>
+              </li>
             </ul>
           </nav>
         </div>

--- a/frontend/app/templates/components/skills-list-row-show.hbs
+++ b/frontend/app/templates/components/skills-list-row-show.hbs
@@ -29,7 +29,7 @@
   {{if this.skill.portfolio this.skill.portfolio "-"}}
 </td>
 <td>
-  <a role="button" onclick={{this.startEditing}} class="edit-buttons skill-edit-button" style='{{unless this.isAdmin "-webkit-filter: grayscale(100%);"}}'>
+  <a role="button" onclick={{this.startEditing}} class="edit-buttons skill-edit-button {{unless this.isAdmin "grayed-out"}}">
     <i class="fa fa-edit"></i>
   </a>
 </td>

--- a/frontend/app/templates/components/skills-list-row-show.hbs
+++ b/frontend/app/templates/components/skills-list-row-show.hbs
@@ -29,7 +29,7 @@
   {{if this.skill.portfolio this.skill.portfolio "-"}}
 </td>
 <td>
-  <a role="button" onclick={{this.startEditing}} class="edit-buttons skill-edit-button">
+  <a role="button" onclick={{this.startEditing}} class="edit-buttons skill-edit-button" style='{{unless this.isAdmin "-webkit-filter: grayscale(100%);"}}'>
     <i class="fa fa-edit"></i>
   </a>
 </td>

--- a/frontend/app/templates/components/skills-list.hbs
+++ b/frontend/app/templates/components/skills-list.hbs
@@ -17,9 +17,15 @@
         </a>
       </div>
       <div class="col-sm-2">
-        <a id="new-skill-link" class="edit-buttons" role="button" data-toggle="modal" data-target="#skill-new-modal">
-          <i class="fa fa-plus" aria-hidden="true"></i> {{t "skills-list.newSkill"}}
-        </a>
+        {{#if this.isAdmin}}
+          <a id="new-skill-link" class="edit-buttons" role="button" data-toggle="modal" data-target="#skill-new-modal">
+            <i class="fa fa-plus" aria-hidden="true" ></i> Neuer Skill
+          </a>
+        {{else}}
+          <a id="new-skill-link" class="edit-buttons" role="button" onclick={{pipe (action "displayCreateSkillError")}} data-target="#skill-new-modal">
+            <i class="fa fa-plus" aria-hidden="true" ></i> Neuer Skill
+          </a>
+        {{/if}}
       </div>
     </div>
   </div>

--- a/frontend/app/templates/components/skills-list.hbs
+++ b/frontend/app/templates/components/skills-list.hbs
@@ -22,7 +22,7 @@
             <i class="fa fa-plus" aria-hidden="true" ></i> Neuer Skill
           </a>
         {{else}}
-          <a id="new-skill-link" class="edit-buttons" role="button" onclick={{pipe (action "displayCreateSkillError")}} data-target="#skill-new-modal">
+          <a id="new-skill-link" class="edit-buttons" style="-webkit-filter: grayscale(100%);" role="button" onclick={{pipe (action "displayCreateSkillError")}} data-target="#skill-new-modal">
             <i class="fa fa-plus" aria-hidden="true" ></i> Neuer Skill
           </a>
         {{/if}}

--- a/frontend/app/templates/components/skills-list.hbs
+++ b/frontend/app/templates/components/skills-list.hbs
@@ -22,7 +22,7 @@
             <i class="fa fa-plus" aria-hidden="true" ></i> Neuer Skill
           </a>
         {{else}}
-          <a id="new-skill-link" class="edit-buttons" style="-webkit-filter: grayscale(100%);" role="button" onclick={{pipe (action "displayCreateSkillError")}} data-target="#skill-new-modal">
+          <a id="new-skill-link" class="edit-buttons grayed-out" role="button" onclick={{pipe (action "displayCreateSkillError")}} data-target="#skill-new-modal">
             <i class="fa fa-plus" aria-hidden="true" ></i> Neuer Skill
           </a>
         {{/if}}

--- a/frontend/tests/acceptance/edit-skill-test.js
+++ b/frontend/tests/acceptance/edit-skill-test.js
@@ -3,6 +3,13 @@ import page from "frontend/tests/pages/skills-index";
 import setupApplicationTest from "frontend/tests/helpers/setup-application-test";
 import { currentURL } from "@ember/test-helpers";
 import { selectChoose } from "ember-power-select/test-support";
+import keycloakStub from "../helpers/keycloak-stub";
+
+const nonAdminKeycloakStub = keycloakStub.extend({
+  hasResourceRole(resource, role) {
+    return false;
+  }
+});
 
 module("Acceptance | edit skill", function(hooks) {
   setupApplicationTest(hooks);
@@ -32,5 +39,11 @@ module("Acceptance | edit skill", function(hooks) {
     assert.ok(rows.includes("Linux-Engineering"));
     assert.ok(rows.includes("assess"));
     assert.ok(rows.includes("aktiv"));
+  });
+  test("can non admin user visit skills", async function(assert) {
+    assert.expect(1);
+    this.owner.register("service:keycloak-session", nonAdminKeycloakStub);
+    await page.indexPage.visit();
+    assert.equal(currentURL(), "/skills");
   });
 });

--- a/frontend/tests/integration/components/skills-list-row-show-test.js
+++ b/frontend/tests/integration/components/skills-list-row-show-test.js
@@ -2,9 +2,16 @@ import { module, test } from "qunit";
 import { setupRenderingTest } from "ember-qunit";
 import { render } from "@ember/test-helpers";
 import hbs from "htmlbars-inline-precompile";
+import keycloakStub from "../../helpers/keycloak-stub";
 
 module("Integration | Component | skills-list-row-show", function(hooks) {
   setupRenderingTest(hooks);
+
+  const nonAdminKeycloakStub = keycloakStub.extend({
+    hasResourceRole(resource, role) {
+      return false;
+    }
+  });
 
   test("it renders", async function(assert) {
     this.set("skill", {
@@ -23,5 +30,15 @@ module("Integration | Component | skills-list-row-show", function(hooks) {
     assert.ok(this.element.textContent.trim().includes("Software-Engineering"));
     assert.ok(this.element.textContent.trim().includes("assess"));
     assert.ok(this.element.textContent.trim().includes("aktiv"));
+  });
+
+  test("it displays grayed out edit icon", async function(assert) {
+    this.owner.register("service:keycloak-session", nonAdminKeycloakStub);
+    await render(hbs`{{skills-list-row-show}}`);
+
+    assert.equal(
+      this.element.querySelector("a").getAttribute("style"),
+      "-webkit-filter: grayscale(100%);"
+    );
   });
 });

--- a/frontend/tests/integration/components/skills-list-row-show-test.js
+++ b/frontend/tests/integration/components/skills-list-row-show-test.js
@@ -14,6 +14,8 @@ module("Integration | Component | skills-list-row-show", function(hooks) {
   });
 
   test("it renders", async function(assert) {
+    this.owner.register("service:keycloak-session", nonAdminKeycloakStub);
+
     this.set("skill", {
       title: "Ruby",
       portfolio: "aktiv",
@@ -37,8 +39,8 @@ module("Integration | Component | skills-list-row-show", function(hooks) {
     await render(hbs`{{skills-list-row-show}}`);
 
     assert.equal(
-      this.element.querySelector("a").getAttribute("style"),
-      "-webkit-filter: grayscale(100%);"
+      this.element.querySelector("a").getAttribute("class"),
+      "edit-buttons skill-edit-button grayed-out"
     );
   });
 });

--- a/frontend/tests/integration/components/skills-list-test.js
+++ b/frontend/tests/integration/components/skills-list-test.js
@@ -91,8 +91,8 @@ module("Integration | Component | skills-list", function(hooks) {
     await render(hbs`{{skills-list}}`);
 
     assert.equal(
-      this.element.querySelector("#new-skill-link").getAttribute("style"),
-      "-webkit-filter: grayscale(100%);"
+      this.element.querySelector("#new-skill-link").getAttribute("class"),
+      "edit-buttons grayed-out"
     );
   });
 

--- a/frontend/tests/integration/components/skills-list-test.js
+++ b/frontend/tests/integration/components/skills-list-test.js
@@ -50,6 +50,12 @@ const storeStub = Service.extend({
   }
 });
 
+const nonAdminKeycloakStub = keycloakStub.extend({
+  hasResourceRole(resource, role) {
+    return false;
+  }
+});
+
 module("Integration | Component | skills-list", function(hooks) {
   setupRenderingTest(hooks);
   setupIntl(hooks);
@@ -69,6 +75,15 @@ module("Integration | Component | skills-list", function(hooks) {
     assert.ok(text.includes("Skill"));
     assert.ok(text.includes("Radar"));
     assert.ok(text.includes("Members"));
+  });
+
+  test("it renders for non admin user", async function(assert) {
+    this.owner.register("service:keycloak-session", nonAdminKeycloakStub);
+    await render(hbs`{{skills-list}}`);
+    let text = this.$().text();
+
+    assert.ok(text.includes("Export"));
+    assert.ok(text.includes("Skill"));
   });
 
   test("it renders with data", async function(assert) {

--- a/frontend/tests/integration/components/skills-list-test.js
+++ b/frontend/tests/integration/components/skills-list-test.js
@@ -86,6 +86,16 @@ module("Integration | Component | skills-list", function(hooks) {
     assert.ok(text.includes("Skill"));
   });
 
+  test("it displays grayed out create skill text", async function(assert) {
+    this.owner.register("service:keycloak-session", nonAdminKeycloakStub);
+    await render(hbs`{{skills-list}}`);
+
+    assert.equal(
+      this.element.querySelector("#new-skill-link").getAttribute("style"),
+      "-webkit-filter: grayscale(100%);"
+    );
+  });
+
   test("it renders with data", async function(assert) {
     this.set("skills", [
       {

--- a/frontend/translations/de.yml
+++ b/frontend/translations/de.yml
@@ -68,6 +68,10 @@ delete-confirmation:
     delete: Löschen
     message: '{name} wirklich löschen?'
     success: '{name} wurde entfernt'
+error-message:
+  unauthorized: Unerlaubt
+  cannotEditSkill: 'Sie sind nicht berechtigt Skills zu bearbeiten!'
+  cannotCreateSkill: 'Sie sind nicht berechtigt Skills zu erstellen!'
 education:
     location: Ausbildungsort
     title: Titel

--- a/frontend/translations/en.yml
+++ b/frontend/translations/en.yml
@@ -68,6 +68,10 @@ delete-confirmation:
     delete: Delete
     message: 'Delete {name}?'
     success: '{name} was deleted'
+error-message:
+  unauthorized: Unauthorised
+  cannotEditSkill: 'You are not authorised to edit skills!'
+  cannotCreateSkill: 'You are not authorised to create skills!'
 education:
     location: Location
     title: Title

--- a/spec/controllers/skills_controller_spec.rb
+++ b/spec/controllers/skills_controller_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 describe SkillsController do
-  describe 'SkillsController' do
+  describe 'SkillsController as admin' do
     before { load_pictures }
 
     before(:each) do
@@ -102,6 +102,89 @@ describe SkillsController do
         skills = json['data']
 
         expect(skills.count).to eq(4)
+      end
+    end
+  end
+  describe 'SkillsController as normal user' do
+    before { load_pictures }
+
+    before(:each) do
+      allow_any_instance_of(SkillsController).to receive(:admin_flag?).and_return(false)
+    end
+
+    let(:bob) { people(:bob) }
+
+    describe 'GET index' do
+      it 'returns all skills with nested models' do
+        keys = %w[title radar portfolio default_set]
+        get :index
+
+        skills = json['data']
+
+        expect(skills.count).to eq(4)
+        bash_attrs = skills.first['attributes']
+        expect(bash_attrs.count).to eq (5)
+        expect(bash_attrs['title']).to eq ('Bash')
+        json_object_includes_keys(bash_attrs, keys)
+      end
+
+      it 'returns skills where title contains a' do
+        get :index, params: { title: 'a' }
+
+        skills = json['data']
+        expect(skills.count).to eq(2)
+        first_skill_attrs = skills.first['attributes']
+        expect(first_skill_attrs['title']).to eq ('Bash')
+        second_skill_attrs = skills.second['attributes']
+        expect(second_skill_attrs['title']).to eq ('Rails')
+      end
+
+      it 'returns skills with default_set true' do
+        get :index, params: { defaultSet: 'true' }
+
+        skills = json['data']
+        expect(skills.count).to eq(1)
+        rails_attrs = skills.first['attributes']
+        expect(rails_attrs['title']).to eq ('Rails')
+      end
+
+      it 'returns skills with default_set new' do
+        get :index, params: { defaultSet: 'new' }
+
+        skills = json['data']
+        expect(skills.count).to eq(1)
+        bash_attrs = skills.first['attributes']
+        expect(bash_attrs['title']).to eq ('Bash')
+      end
+
+      it 'returns skills with parent category software-engineering' do
+        parent_category = categories(:'software-engineering')
+        get :index, params: { category: parent_category.id }
+
+        skills = json['data']
+        expect(skills.count).to eq(3)
+        cunit_attrs = skills.first['attributes']
+        junit_attrs = skills.second['attributes']
+        rails_attrs = skills.third['attributes']
+        expect(cunit_attrs['title']).to eq ('cunit')
+        expect(junit_attrs['title']).to eq ('JUnit')
+        expect(rails_attrs['title']).to eq ('Rails')
+      end
+
+      it 'returns skills with parent category software-engineering and defaultSet true' do
+        parent_category = categories(:'software-engineering')
+        get :index, params: { category: parent_category.id, defaultSet: 'true' }
+
+        skills = json['data']
+        expect(skills.count).to eq(1)
+        rails_attrs = skills.first['attributes']
+        expect(rails_attrs['title']).to eq ('Rails')
+      end
+    end
+    describe 'Can not edit as normal user' do
+      it 'raises error when editing as normal user' do
+        process :update, method: :put, params: { id: Skill.last.id, data: { skill: {title: "Updated"} } }
+        expect(response.status).to eq 401
       end
     end
   end


### PR DESCRIPTION
[Issue 354](https://github.com/puzzle/skills/issues/354)
The skillset page should become read-only for all non-admin members. Meaning these non-admin members will be able to view the page but won't be able to edit anything.