### PR TITLE
feat(nix): add Nix dev shell and justfile for local development

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@
 
 # Ignore bundler config.
 /.bundle
+# Nix dev shell: gems installed into the project
+/vendor/bundle
 
 # Ignore the default SQLite database.
 /db/*.sqlite3

--- a/README.md
+++ b/README.md
@@ -117,6 +117,59 @@ postgres:18        "docker-entrypoint.s…"    11 seconds ago   Up 10 seconds   
 
 Access the web application by browser: http://localhost:3000 and enjoy the ride!
 
+## Setup with Nix ❄️
+As an alternative to the Docker setup, you can use the [Nix](https://nixos.org/) flake in the
+repository root. It provides a reproducible dev shell with the whole toolchain pinned to match
+the project plus native libraries the gems need.
+Nothing is installed globally — gems land in `vendor/bundle` and a project-local PostgreSQL
+cluster lives in `tmp/postgres`.
+
+You need a [Nix installation with flakes enabled](https://nixos.org/download/) (the
+[Determinate Systems installer](https://github.com/DeterminateSystems/nix-installer) enables
+them by default). Then, from the project root:
+
+```bash
+nix develop
+```
+
+This drops you into a shell with every tool on the `PATH` and the database/env variables
+preconfigured. From there, `just` (see below) handles setup and the everyday workflow:
+
+```bash
+just init   # install gems + JS deps and create a ready-to-use database
+just dev    # start the full dev stack (web + JS/CSS watchers)
+```
+
+## Task runner (`just`)
+The repository ships a [`justfile`](justfile) with recipes for the everyday workflow. List all
+available recipes with:
+
+```bash
+just            # equivalent to: just --list
+```
+
+Frequently used recipes:
+
+| Recipe          | Description                                               |
+|-----------------|-----------------------------------------------------------|
+| `just init`     | One-shot setup: gems, JS deps and a ready-to-use database |
+| `just deps`     | Install Ruby gems and JS dependencies                     |
+| `just dev`      | Run the full dev stack (web + JS/CSS watchers)            |
+| `just server`   | Run only the Rails server                                 |
+| `just console`  | Open a Rails console                                      |
+| `just test`     | Run the RSpec suite (e.g. `just test spec/models`)        |
+| `just lint`     | Run RuboCop (`just lint-fix` to autocorrect)              |
+| `just db`       | Create + migrate the development and test databases       |
+| `just db-reset` | Drop, recreate, migrate and seed the databases            |
+| `just psql`     | Open a psql shell on the development database             |
+| `just clean`    | Stop services and clear Rails logs/tmp                    |
+
+`just` does **not** require `nix` if you already have the toolchain (Ruby, Node/Yarn, PostgreSQL)
+available, simply [install `just`](https://github.com/casey/just#installation) and run the
+recipes directly. Note that the database recipes expect the project-local PostgreSQL environment
+variables (`PGDATA`, `PGHOST`, `PGPORT`, `PGUSER`) that the Nix shell sets up; outside the Nix
+shell you either provide equivalent values yourself or use your own PostgreSQL instance.
+
 ## Skill snapshot for departments
 The core competence of this feature is to track how many people in a department have a given skill. This also includes tracking the level of the skill.
 It works by running a monthly DelayedJob that creates these 'Snapshots' for each department.

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,27 @@
+{
+  "nodes": {
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1781577229,
+        "narHash": "sha256-lrp67w8AulE9Ks53n27I45ADSzbOCn4H+CNW1Ck8B+8=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "567a49d1913ce81ac6e9582e3553dd90a955875f",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,76 @@
+{
+  description = "Dev shell for the Skills Rails app (Ruby 4.0 / Node 24 / PostgreSQL 18)";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+  };
+
+  outputs = { self, nixpkgs }:
+    let
+      systems = [ "x86_64-linux" "aarch64-linux" "x86_64-darwin" "aarch64-darwin" ];
+      forEachSystem = f: nixpkgs.lib.genAttrs systems (system: f nixpkgs.legacyPackages.${system});
+    in
+    {
+      devShells = forEachSystem (pkgs: {
+        default = pkgs.mkShell {
+          # Toolchain pinned to match .tool-versions / docker-compose.yml.
+          # (nixpkgs ships Ruby 4.0.5; the project requests 4.0.1 — patch-compatible.)
+          packages = with pkgs; [
+            ruby_4_0
+            nodejs_24       # bundles corepack, which provides yarn 4.12.0
+            postgresql_18
+            just            # task runner (see ./justfile)
+
+            # Build/runtime deps for native gems
+            pkg-config
+            libxml2         # nokogiri
+            libxslt         # nokogiri
+            libffi          # ffi / ruby-vips
+            libyaml         # psych
+            openssl
+            zlib
+            postgresql_18.lib  # libpq for the pg gem
+            vips            # ruby-vips (loaded at runtime via FFI)
+            imagemagick     # mini_magick (shells out to the CLI)
+          ];
+
+          shellHook = ''
+            # --- Project-local state, nothing installed globally -----------------
+            export PROJECT_ROOT="$PWD"
+            export BUNDLE_PATH="$PROJECT_ROOT/vendor/bundle"
+            export BUNDLE_BIN="$PROJECT_ROOT/vendor/bundle/bin"
+            export GEM_HOME="$BUNDLE_PATH"
+            export PATH="$BUNDLE_BIN:$PATH"
+
+            # Yarn 4.12 via corepack, kept inside the project.
+            # `corepack enable` requires the target dir to exist beforehand.
+            export COREPACK_HOME="$PROJECT_ROOT/tmp/corepack"
+            mkdir -p "$PROJECT_ROOT/tmp/corepack-bin"
+            corepack enable --install-directory "$PROJECT_ROOT/tmp/corepack-bin" >/dev/null 2>&1 || true
+            export PATH="$PROJECT_ROOT/tmp/corepack-bin:$PATH"
+
+            # --- Database connection (matches config/database.yml defaults) ------
+            export RAILS_DB_HOST="127.0.0.1"
+            export RAILS_DB_PORT="5432"
+            export RAILS_DB_USERNAME="skills"
+            export RAILS_DB_PASSWORD="skills"
+
+            # --- Project-local PostgreSQL (managed via the justfile) -------------
+            export PGDATA="$PROJECT_ROOT/tmp/postgres/data"
+            export PGHOST="$PROJECT_ROOT/tmp/postgres/sockets"
+            export PGPORT="5432"
+            export PGUSER="skills"
+
+            cat <<'EOF'
+
+  Skills dev shell ready. Tasks are managed with `just` — run `just` for the list.
+
+  First time:   just init     (gems + JS deps + database)
+  Develop:      just dev       Test: just test       Lint: just lint
+
+EOF
+          '';
+        };
+      });
+    };
+}

--- a/flake.nix
+++ b/flake.nix
@@ -17,7 +17,8 @@
           # (nixpkgs ships Ruby 4.0.5; the project requests 4.0.1 — patch-compatible.)
           packages = with pkgs; [
             ruby_4_0
-            nodejs_24       # bundles corepack, which provides yarn 4.12.0
+            nodejs_24       # Node 24 runtime (also ships corepack and yarn 4.12.1)
+            #yarn-berry_4    # Yarn 4.14.x — matches the Yarn 4 line pinned in package.json
             postgresql_18
             just            # task runner (see ./justfile)
 
@@ -35,7 +36,23 @@
             graphicsmagick
           ];
 
+          # Static env vars: any non-special attribute is exported into the shell.
+          # (Path-derived vars that need $PWD live in shellHook — see below.)
+
+          # Database connection (matches config/database.yml defaults).
+          RAILS_DB_HOST = "127.0.0.1";
+          RAILS_DB_PORT = "5432";
+          RAILS_DB_USERNAME = "skills";
+          RAILS_DB_PASSWORD = "skills";
+
+          # Project-local PostgreSQL (managed via the justfile).
+          PGPORT = "5432";
+          PGUSER = "skills";
+
           shellHook = ''
+            # Path-derived vars: kept here because attribute values are not
+            # shell-expanded, so $PWD must be resolved at shell-entry time.
+
             # --- Project-local state, nothing installed globally -----------------
             export PROJECT_ROOT="$PWD"
             export BUNDLE_PATH="$PROJECT_ROOT/vendor/bundle"
@@ -43,33 +60,18 @@
             export GEM_HOME="$BUNDLE_PATH"
             export PATH="$BUNDLE_BIN:$PATH"
 
-            # Yarn 4.12 via corepack, kept inside the project.
-            # `corepack enable` requires the target dir to exist beforehand.
-            export COREPACK_HOME="$PROJECT_ROOT/tmp/corepack"
-            mkdir -p "$PROJECT_ROOT/tmp/corepack-bin"
-            corepack enable --install-directory "$PROJECT_ROOT/tmp/corepack-bin" >/dev/null 2>&1 || true
-            export PATH="$PROJECT_ROOT/tmp/corepack-bin:$PATH"
+            # Yarn 4 comes from nixpkgs (yarn-berry_4) — no corepack download needed.
 
-            # --- Database connection (matches config/database.yml defaults) ------
-            export RAILS_DB_HOST="127.0.0.1"
-            export RAILS_DB_PORT="5432"
-            export RAILS_DB_USERNAME="skills"
-            export RAILS_DB_PASSWORD="skills"
-
-            # --- Project-local PostgreSQL (managed via the justfile) -------------
+            # --- Project-local PostgreSQL data dir / socket ----------------------
             export PGDATA="$PROJECT_ROOT/tmp/postgres/data"
             export PGHOST="$PROJECT_ROOT/tmp/postgres/sockets"
-            export PGPORT="5432"
-            export PGUSER="skills"
 
-            cat <<'EOF'
-
-  Skills dev shell ready. Tasks are managed with `just` — run `just` for the list.
-
-  First time:   just init     (gems + JS deps + database)
-  Develop:      just dev       Test: just test       Lint: just lint
-
-EOF
+            echo
+            echo '  Skills dev shell ready. Tasks are managed with `just` — run `just` for the list.'
+            echo
+            echo '  First time:   just init     (gems + JS deps + database)'
+            echo '  Develop:      just dev       Test: just test       Lint: just lint'
+            echo
           '';
         };
       });

--- a/flake.nix
+++ b/flake.nix
@@ -32,6 +32,7 @@
             postgresql_18.lib  # libpq for the pg gem
             vips            # ruby-vips (loaded at runtime via FFI)
             imagemagick     # mini_magick (shells out to the CLI)
+            graphicsmagick
           ];
 
           shellHook = ''

--- a/justfile
+++ b/justfile
@@ -1,0 +1,131 @@
+# Task runner for the Skills app. Run inside the nix dev shell (`nix develop`).
+# `just` itself is provided by flake.nix. List all recipes with `just`.
+
+set shell := ["bash", "-uc"]
+
+# Show all available recipes
+default:
+    @just --list
+
+# --- Setup -------------------------------------------------------------------
+
+# One-shot environment setup: gems, JS deps and a ready-to-use database
+init: deps db
+    @echo "==> Done. Start developing with: just dev"
+
+# Install Ruby gems (-> vendor/bundle) and JS deps (yarn 4 via corepack)
+deps:
+    bundle install
+    yarn install
+
+# --- Database (project-local PostgreSQL in tmp/postgres) ---------------------
+
+# Start PostgreSQL, initializing the cluster on first run (idempotent)
+[group('db')]
+db-start:
+    #!/usr/bin/env bash
+    set -euo pipefail
+    if pg_ctl -D "$PGDATA" status >/dev/null 2>&1; then
+        echo "PostgreSQL already running on port $PGPORT"
+        exit 0
+    fi
+    if [ ! -d "$PGDATA" ]; then
+        echo "==> Initializing PostgreSQL cluster in $PGDATA"
+        mkdir -p "$PGDATA"
+        # trust auth: local-only dev DB. Rails still sends skills/skills; accepted.
+        initdb --username=skills --auth=trust "$PGDATA" >/dev/null
+    fi
+    mkdir -p "$PGHOST"
+    pg_ctl -D "$PGDATA" -l "$PGDATA/../server.log" \
+        -o "-c listen_addresses=127.0.0.1 -p $PGPORT -c unix_socket_directories=$PGHOST" \
+        start
+
+# Stop PostgreSQL (no error if it is not running)
+[group('db')]
+db-stop:
+    @pg_ctl -D "$PGDATA" stop 2>/dev/null || echo "PostgreSQL not running"
+
+# Show PostgreSQL server status
+[group('db')]
+db-status:
+    @pg_ctl -D "$PGDATA" status || true
+
+# Create + migrate the development and test databases
+[group('db')]
+db: db-start
+    bin/rails db:prepare
+
+# Run pending migrations
+[group('db')]
+db-migrate: db-start
+    bin/rails db:migrate
+
+# Drop, recreate, migrate and seed the databases
+[group('db')]
+db-reset: db-start
+    bin/rails db:reset
+
+# Load seed data
+[group('db')]
+db-seed: db-start
+    bin/rails db:seed
+
+# Open a psql shell on the development database
+[group('db')]
+psql: db-start
+    psql -h 127.0.0.1 -p "$PGPORT" -U skills -d skills_development
+
+# --- Develop / run -----------------------------------------------------------
+
+# Run the full dev stack: web + js + css watchers (Procfile.dev)
+dev: db-start
+    bin/dev
+
+# Run only the Rails server
+[group('run')]
+server: db-start
+    bin/rails server
+
+# Open a Rails console
+[group('run')]
+console: db-start
+    bin/rails console
+
+# Build JS and CSS assets once
+[group('run')]
+assets:
+    yarn build
+    yarn build:css
+
+# Show all routes
+[group('run')]
+routes:
+    bin/rails routes
+
+# --- Test & quality ----------------------------------------------------------
+
+# Run the RSpec suite (pass extra args, e.g. `just test spec/models`)
+test *args: db-start
+    bundle exec rspec {{args}}
+
+# Run RuboCop
+lint:
+    bundle exec rubocop
+
+# Run RuboCop with autocorrect
+lint-fix:
+    bundle exec rubocop -A
+
+# Brakeman security scan
+brakeman:
+    bin/brakeman
+
+# Check gems for known vulnerabilities
+audit:
+    bin/bundler-audit check --update
+
+# --- Maintenance -------------------------------------------------------------
+
+# Stop services and clear Rails logs/tmp
+clean: db-stop
+    bin/rails log:clear tmp:clear

--- a/justfile
+++ b/justfile
@@ -13,7 +13,7 @@ default:
 init: deps db
     @echo "==> Done. Start developing with: just dev"
 
-# Install Ruby gems (-> vendor/bundle) and JS deps (yarn 4 via corepack)
+# Install Ruby gems (-> vendor/bundle) and JS deps (yarn 4 from the nix shell)
 deps:
     bundle install
     yarn install


### PR DESCRIPTION
## What

Adds a reproducible, Nix-based development environment so the project can be built and tested without installing the toolchain globally — as an alternative to the existing Docker Compose setup.

### `flake.nix` — dev shell
Provides a `nix develop` shell with the toolchain pinned to match `.tool-versions` / `docker-compose.yml`:

- **Ruby 4.0** (nixpkgs ships 4.0.5; the project requests 4.0.1 — patch-compatible)
- **Node 24** with **Yarn 4.12** via corepack
- **PostgreSQL 18**
- **just** (task runner)
- Native build/runtime deps for the gems: `libxml2`/`libxslt` (nokogiri), `libffi` & `vips` (ruby-vips), `imagemagick` (mini_magick), `libpq` (pg), `openssl`, `zlib`, `libyaml`

The shell hook keeps all state inside the project (`vendor/bundle` for gems, `tmp/corepack-bin` for the Yarn shim, `tmp/postgres` for a project-local database) and exports the `RAILS_DB_*` / `PG*` variables matching `config/database.yml`.

### `justfile` — task runner
Common tasks, grouped (`just` lists them all):

- **Setup:** `just init` (deps + database), `just deps`
- **Database:** project-local PostgreSQL in `tmp/postgres` — `just db-start` / `db-stop` / `db-status`, plus `db` (prepare), `db-migrate`, `db-reset`, `db-seed`, `psql`
- **Run:** `just dev` (Procfile.dev stack), `server`, `console`, `assets`, `routes`
- **Test & quality:** `just test [path]`, `lint`, `lint-fix`, `brakeman`, `audit`
- **Maintenance:** `just clean`

### `.gitignore`
Ignores `/vendor/bundle` (gems are installed into the project by the dev shell).

## Usage

```bash
nix develop      # enter the shell
just init        # gems + JS deps + database
just dev         # run the app
just test        # run the suite
```

## Notes

- The PostgreSQL cluster uses `trust` auth — it is a local-only dev database.
- On non-NixOS Linux (e.g. Arch) the precompiled native gems work directly; Nix only supplies the toolchain.
- Docker Compose remains fully usable; this is purely additive.