### PR TITLE
Hide add button when not authorized  

### DIFF
--- a/app/views/skills/_header.html.haml
+++ b/app/views/skills/_header.html.haml
@@ -17,4 +17,5 @@
           = "#{Category.model_name.human}:"
         = form.collection_select :category, Category.all_parents.order(:title), :id, :title, {prompt: true}, class: "form-select fit-content", onchange: 'this.form.requestSubmit();'
       = admin_export_action_link  export_skills_path, "data-turbo-prefetch": false , data: { turbo: false }
-      = add_action_link_modal
+      - if admin?
+        = add_action_link_modal

--- a/spec/features/auth_spec.rb
+++ b/spec/features/auth_spec.rb
@@ -14,8 +14,7 @@ describe 'Check authentications', type: :feature, js: true do
 
     it 'Cannot create new skill' do
       visit skills_path
-      click_link(href: new_skill_path)
-      expect(page).to have_content("401 Keine ausreichenden Berechtigungen")
+      expect(page).not_to have_link(href: new_skill_path)
     end
   end
 

--- a/spec/features/skills_controller_spec.rb
+++ b/spec/features/skills_controller_spec.rb
@@ -79,6 +79,19 @@ describe :skills do
     end
   end
 
+  describe 'Add skill' do
+    it 'shows the add button when admin' do
+      visit skills_path
+      expect(page).to have_css('.icon.icon-plus')
+    end
+
+    it 'hides the add button when not admin' do
+      sign_in auth_users(:user), scope: :auth_user
+      visit skills_path
+      expect(page).not_to have_css('.icon.icon-plus')
+    end
+  end
+
   describe 'sort skillsets' do
     it 'should be able to sort skillset table' do
       visit skills_path


### PR DESCRIPTION
## Description of feature or bug

Don't show the add button in skillset when you are not authorized
to create a skill.

## TODO

- [x] Hide add button when not authorized

## Fix

The add-skill button in `skills/_header.html.haml` was rendered
unconditionally, even though `SkillsController` already restricts
`create`/`new` to admins (`render_unauthorized_not_admin`). Wrapped
it in `- if admin?`, matching the pattern already used elsewhere
(e.g. `layouts/application.html.haml`).

Added feature-spec coverage in `skills_controller_spec.rb` confirming
the button shows for admins and is hidden for non-admins.

Closes #1235 